### PR TITLE
Refactor QA planner for pluggable tracing and LLM client

### DIFF
--- a/agents/attackers/llm_qa/README.md
+++ b/agents/attackers/llm_qa/README.md
@@ -1,37 +1,46 @@
 # NetSecGame LLM REACT+ Agent
 
-This repository provides an implementation of an attacker agent for NetSecGame controlled using a Large Language Model (LLM). The agent uses ReAct-style prompting and memory to plan and take actions in a simulated environment.
+This directory contains an attacker agent for NetSecGame that relies on a
+Large Language Model (LLM) to plan actions using the ReAct technique and a
+rolling memory of past steps.
 
 ## Supported models
 
+The agent can interact with any OpenAI model or an OpenAI-compatible endpoint
+such as [Ollama](https://ollama.ai/).
 
-Supported models include OpenAI's GPT family and others local models using Ollama API
-
-- GPT4 (OpenAI)
-- GPT-4-turbo (OpenAI)
-- GPT-3.5-turbo (OpenAI)
-- GPT-3.5-turbo-16k (OpenAI)
-- GPT4o-mini (OpenAI)
-- GPT4o (OpenAI)
-- Any local instruction model compatible with the OpenAI API should work, however there is no guarantee it can solve any scenario.
+- GPT-4
+- GPT-4-turbo
+- GPT-3.5-turbo
+- GPT-3.5-turbo-16k
+- GPT4o / GPT4o-mini
+- Any local instruction model exposed through an OpenAI-compatible API
 
 ## Features
 
-- Uses LLMs to control an agent in a simulated cybersecurity game
-- Supports OpenAI and Hugging Face APIs
-- Collects detailed metrics with MLflow
-- Tracks prompts, LLM responses, and evaluation data
-- Saves all interaction data in JSON format
-- Allows configurable memory buffer for multi-step planning
+- Unified `LLMClient` for OpenAI or custom `--base_url`
+- Optional tracing with Langfuse via `--enable_tracing` (falls back to a
+  no-op tracer if the SDK or credentials are missing)
+- MLflow integration for experiment tracking
+- ReAct prompting with configurable memory buffer
+- All prompts, responses and evaluations stored as JSON
+
+## Recent changes
+
+- `LLMActionPlanner` now inherits from `LLMActionPlannerBase` for easier
+  extension
+- Tracing is handled by a small abstraction in `tracer.py`
+- Langfuse usage is opt-in with a flag instead of a hard dependency
+- The agent accepts `--base_url` to target local endpoints like Ollama
 
 ## Prerequisites
 
 - Python 3.12+
 - A running instance of the NetSecGame server
-- MLflow tracking server (optional but recommended)
-- Access to OpenAI API, a locally hosted Ollama API or any other OpenAI compatible API.
+- Optional MLflow tracking server
+- Access to an OpenAI API key or a local OpenAI-compatible endpoint
 
-Install required Python packages:
+Install the required Python packages:
 
 ```bash
 pip install -r requirements.txt
@@ -39,32 +48,39 @@ pip install -r requirements.txt
 
 ## Usage
 
-Run the agent with a local model
+Run the agent against a local Ollama model:
 
 ```bash
-python llm_agent_qa.py --llm llama3.1:8b --test_episodes 20 --memory_buffer 5 --api_url http://localhost:11434/v1/
+python llm_agent_qa.py --llm llama3.1:8b --test_episodes 20 --memory_buffer 5 \
+    --base_url http://localhost:11434/v1/
+```
+
+Enable Langfuse tracing (credentials and SDK must be available):
+
+```bash
+python llm_agent_qa.py --llm gpt-4 --enable_tracing
 ```
 
 ### Arguments
 
-| Argument          | Description                                | Default                       |
-|-------------------|--------------------------------------------|-------------------------------|
-| `--llm`           | LLM model to use (e.g.gpt-4,lama3.1`)      | `gpt4o-mini`        		 |
-| `--test_episodes` | Number of test episodes to run             | `30`                          |
-| `--memory_buffer` | Number of past actions to remember         | `5`                           |
-| `--host`          | Host address of the NetSecGame server      | `127.0.0.1`                   |
-| `--port`          | Port number of the server                  | `9000`                        |
-| `--api_url`       | Endpoint for OpenAI or Ollama model API    | `http://127.0.0.1:11434/v1/`  |
-| `-disable_mlflow` | Disable mlflow logging			 | `False`  			 |
-
+| Argument           | Description                                | Default     |
+|--------------------|--------------------------------------------|-------------|
+| `--llm`            | LLM model to use                           | `gpt4o-mini`|
+| `--test_episodes`  | Number of test episodes to run             | `30`        |
+| `--memory_buffer`  | Number of past actions to remember         | `5`         |
+| `--host`           | Host address of the NetSecGame server      | `127.0.0.1` |
+| `--port`           | Port number of the server                  | `9000`      |
+| `--base_url`       | Base URL for OpenAI-compatible APIs        | `None`      |
+| `--enable_tracing` | Enable Langfuse tracing if available       | `False`     |
+| `--disable_mlflow` | Disable MLflow logging                     | `False`     |
 
 ## Output and Logging
 
-- Metrics like win rate, detection rate, and returns are logged to MLflow
-- All prompts, responses, and evaluations are stored in `episode_data.json`
+- Metrics like win rate, detection rate and returns are logged to MLflow
+- Prompts, responses and evaluations are stored in `episode_data.json`
 - Execution logs are written to `llm_qa.log`
 
-To view experiment results, start the MLflow UI:
+Start the MLflow UI to inspect results:
 
 ```bash
 mlflow ui
@@ -72,22 +88,26 @@ mlflow ui
 
 Then visit [http://localhost:5000](http://localhost:5000) in your browser.
 
-## How It Works
+## How it works
 
 1. The agent registers with the game server.
-2. At each step, the environment state and past memory are passed to the LLM.
+2. For each step, the environment state and memory are sent to the LLM.
 3. The LLM returns a JSON-formatted action plan.
 4. The environment executes the action and provides feedback.
-5. Feedback is stored and used to inform future steps via a rolling memory window.
-6. Prompts for the agents are located in `prompts.yaml`
-
+5. Feedback is stored and used for future decisions via a rolling memory
+   window.
+6. Prompts are defined in `prompts.yaml`.
 
 ## License
 
 This project is licensed under the MIT License.
 
-# Publications
+## Publications
 
-[1] Rigaki, M., Lukáš, O., Catania, C., & Garcia, S. (2024). Out of the cage: How stochastic parrots win in cyber security environments. In Proceedings of the 16th International Conference on Agents and Artificial Intelligence (pp. 774–781). SCITEPRESS – Science and Technology Publications. [https://doi.org/10.5220/0012391800003636](https://doi.org/10.5220/0012391800003636)
+- Rigaki, M., Lukáš, O., Catania, C., & Garcia, S. (2024). *Out of the cage:
+  How stochastic parrots win in cyber security environments*. In Proceedings of
+  the 16th International Conference on Agents and Artificial Intelligence
+  (pp. 774–781). SCITEPRESS.
+- Rigaki, M., Catania, C., & Garcia, S. (2024). *Hackphyr: A local fine-tuned
+  LLM agent for network security environments*. arXiv. <https://arxiv.org/abs/2409.11276>
 
-[2] Rigaki, M., Catania, C., & Garcia, S. (2024). Hackphyr: A local fine-tuned LLM agent for network security environments. arXiv. [https://arxiv.org/abs/2409.11276](https://arxiv.org/abs/2409.11276)

--- a/agents/attackers/llm_qa/llm_action_planner.py
+++ b/agents/attackers/llm_qa/llm_action_planner.py
@@ -1,10 +1,39 @@
+"""
+@file llm_action_planner.py
+
+@brief Implementation of an LLM-based action planner for reactive agent systems.
+
+This module defines the ``LLMActionPlanner`` which orchestrates interactions with a
+language model to plan actions via the ReAct technique. It leverages the generic
+``LLMActionPlannerBase`` for provider-agnostic LLM access and optional tracing
+support. The core logic mirrors the original implementation but delegates LLM and
+tracer specifics to injected dependencies.
+
+Most of the code is adapted from the original ``assistant.py`` from the
+``interactive_tui`` agent.
+
+@author Maria Rigaki - maria.rigaki@aic.fel.cvut.cz
+@author Harpo Maxx - harpomaxx@gmail.com
+
+@date [Date]
+"""
+
 from __future__ import annotations
 import json
 import logging
-from AIDojoCoordinator.game_components import Observation
+from AIDojoCoordinator.game_components import ActionType, Observation
 from NetSecGameAgents.agents.llm_utils import create_status_from_state
 from .llm_action_planner_base import LLMActionPlannerBase
 import validate_responses
+
+
+ACTION_MAPPER = {
+    "ScanNetwork": ActionType.ScanNetwork,
+    "ScanServices": ActionType.FindServices,
+    "FindData": ActionType.FindData,
+    "ExfiltrateData": ActionType.ExfiltrateData,
+    "ExploitService": ActionType.ExploitService,
+}
 
 class LLMActionPlanner(LLMActionPlannerBase):
     def __init__(

--- a/agents/attackers/llm_qa/llm_action_planner.py
+++ b/agents/attackers/llm_qa/llm_action_planner.py
@@ -1,503 +1,104 @@
-"""
-@file llm_action_planner.py
-
-@brief Implementation of an LLM-based action planner for reactive agent systems.
-
-This script defines classes and methods to facilitate interaction with language models (LLMs),
-manage configuration files, and parse responses from LLM queries. The core functionality includes
-planning actions based on observations and memory, parsing LLM responses, and dynamically loading
-configuration files using YAML. Most of the code is adapted from the original implementation in 
-the `assistan.py` from the `interactive_tui` agent.
-
-@author Maria Rigaki - maria.rigaki@aic.fel.cvut.cz
-@author Harpo Maxx - harpomaxx@gmail.com
-
-@date [Date]
-"""
-
-import sys
-from os import path
-import yaml
-import logging
+from __future__ import annotations
 import json
-from dotenv import dotenv_values
-from openai import OpenAI
-from tenacity import retry, stop_after_attempt
-import jinja2
-
-import re
-from collections import Counter
+import logging
+from AIDojoCoordinator.game_components import Observation
+from NetSecGameAgents.agents.llm_utils import create_status_from_state
+from .llm_action_planner_base import LLMActionPlannerBase
 import validate_responses
 
-# Add parent directories dynamically
-sys.path.append(
-    path.dirname(path.dirname(path.dirname(path.dirname(path.dirname(path.abspath(__file__))))))
-)
-sys.path.append(path.dirname(path.dirname(path.dirname(path.abspath(__file__)))))
-
-from AIDojoCoordinator.game_components import ActionType, Observation
-from NetSecGameAgents.agents.llm_utils import create_action_from_response, create_status_from_state
-
-
-class ConfigLoader:
-    """Class to handle loading YAML configurations."""
-    
-    @staticmethod
-    def load_config(file_name: str = 'prompts.yaml') -> dict:
-        possible_paths = [
-            path.join(path.dirname(__file__), file_name),
-            path.join(path.dirname(path.dirname(__file__)), file_name),
-            path.join(path.dirname(path.dirname(path.dirname(__file__))), file_name),
-        ]
-        for yaml_file in possible_paths:
-            if path.exists(yaml_file):
-                with open(yaml_file, 'r') as file:
-                    return yaml.safe_load(file)
-        raise FileNotFoundError(f"{file_name} not found in expected directories.")
-
-
-ACTION_MAPPER = {
-    "ScanNetwork": ActionType.ScanNetwork,
-    "ScanServices": ActionType.FindServices,
-    "FindData": ActionType.FindData,
-    "ExfiltrateData": ActionType.ExfiltrateData,
-    "ExploitService": ActionType.ExploitService,
-}
-
-
-from dotenv import load_dotenv
-import os
-from langfuse import get_client
-
-# Cargar las variables de entorno desde el archivo .env
-load_dotenv()
-
-# Configurar las variables de entorno para Langfuse (opcional, pero claro)
-os.environ["LANGFUSE_PUBLIC_KEY"] = os.getenv("LANGFUSE_PUBLIC_KEY")
-os.environ["LANGFUSE_SECRET_KEY"] = os.getenv("LANGFUSE_SECRET_KEY")
-os.environ["LANGFUSE_HOST"] = os.getenv("LANGFUSE_HOST")
-
-# Inicializar el cliente de Langfuse con manejo de errores
-try:
-    langfuse = get_client()
-    print("✅ Langfuse initialized successfully")
-except Exception as e:
-    print(f"⚠️ Warning: Langfuse initialization failed: {e}")
-    langfuse = None
-
-
-class LLMActionPlanner:
-    def __init__(self, model_name: str, goal: str, memory_len: int = 10, api_url=None, config: dict = None, use_reasoning: bool = False, use_reflection: bool = False, use_self_consistency: bool = False):
-        self.model = model_name
-        self.config = config or ConfigLoader.load_config()
-        self.use_reasoning = use_reasoning
-        self.use_reflection = use_reflection
-        self.use_self_consistency = use_self_consistency
-
-        if "gpt" in self.model:
-            env_config = dotenv_values(".env")
-            self.client = OpenAI(api_key=env_config["OPENAI_API_KEY"])
-        else:
-            self.client = OpenAI(base_url=api_url, api_key="ollama")
-
-        self.memory_len = memory_len
-        self.logger = logging.getLogger("REACT-agent")
-        self.update_instructions(goal.lower())
-        self.prompts = []
-        self.states = []
-        self.responses = []
-        
-        # Initialize Langfuse session tracking
-        self.session_id = f"agent-session-{hash(goal)}"
-        self.current_span = None
-
-    def get_prompts(self) -> list:
-        """
-        Returns the list of prompts sent to the LLM."""
-        return self.prompts
-
-    def get_responses(self) -> list:
-        """
-        Returns the list of responses received from the LLM. Only Stage 2 responses are included.
-        """
-        return self.responses
-    
-    def get_states(self) -> list:
-        """
-        Returns the list of states received from the LLM. In JSON format.
-        """
-        return self.states
-    
-    def update_instructions(self, new_goal: str) -> None:
-        template = jinja2.Environment().from_string(self.config['prompts']['INSTRUCTIONS_TEMPLATE'])
-        self.instructions = template.render(goal=new_goal)
-
-    def create_mem_prompt(self, memory_list: list) -> str:
-        prompt = ""
-        for memory, goodness in memory_list:
-            prompt += f"You have taken action {memory} in the past. This action was {goodness}.\n"
-        return prompt
-
-    @retry(stop=stop_after_attempt(3))
-    def openai_query(self, msg_list: list, max_tokens: int = 60, model: str = None, fmt=None, temperature: float = 0.0, parent_span=None):
-        # Track LLM generation in Langfuse using v3 API
-        if langfuse and parent_span:
-            try:
-                with langfuse.start_as_current_generation(
-                    name="llm-query",
-                    model=model or self.model,
-                    input=msg_list,
-                    model_parameters={
-                        "max_tokens": max_tokens,
-                        "temperature": temperature,
-                        "response_format": str(fmt) if fmt else "text"
-                    }
-                ) as generation:
-                    
-                    llm_response = self.client.chat.completions.create(
-                        model=model or self.model,
-                        messages=msg_list,
-                        max_tokens=max_tokens,
-                        temperature=temperature,
-                        response_format=fmt or {"type": "text"},
-                    )
-                    
-                    response_content = llm_response.choices[0].message.content
-                    
-                    # Update generation with response and usage
-                    usage_dict = None
-                    if hasattr(llm_response, 'usage') and llm_response.usage:
-                        usage_dict = {
-                            "input_tokens": llm_response.usage.prompt_tokens,
-                            "output_tokens": llm_response.usage.completion_tokens,
-                            "total_tokens": llm_response.usage.total_tokens
-                        }
-                    
-                    generation.update(
-                        output=response_content,
-                        usage=usage_dict
-                    )
-                    
-                    return response_content
-            except Exception as e:
-                print(f"Warning: Error with Langfuse generation tracking: {e}")
-                # Fallback to regular OpenAI call
-                pass
-        
-        # Fallback or when Langfuse is not available
-        llm_response = self.client.chat.completions.create(
-            model=model or self.model,
-            messages=msg_list,
-            max_tokens=max_tokens,
-            temperature=temperature,
-            response_format=fmt or {"type": "text"},
+class LLMActionPlanner(LLMActionPlannerBase):
+    def __init__(
+        self,
+        model_name: str,
+        goal: str,
+        llm,
+        tracer,
+        memory_len: int = 10,
+        config: dict | None = None,
+        use_reasoning: bool = False,
+        use_reflection: bool = False,
+        use_self_consistency: bool = False,
+    ) -> None:
+        super().__init__(
+            model_name=model_name,
+            goal=goal,
+            llm=llm,
+            tracer=tracer,
+            memory_len=memory_len,
+            config=config,
+            use_reasoning=use_reasoning,
+            use_reflection=use_reflection,
+            use_self_consistency=use_self_consistency,
         )
-        
-        return llm_response.choices[0].message.content
-
-    def parse_response_deprecated(self, llm_response: str, state: Observation.state):
-        try:
-            response = json.loads(llm_response)
-        except json.JSONDecodeError:
-            self.logger.error("Failed to parse LLM response as JSON.")
-            return False,llm_response, None
-
-        try:
-            action_str = response["action"]
-            action_params = response["parameters"]
-            valid, action = create_action_from_response(response, state)
-            #return valid,f"You can take action {action_str} with parameters {action_params}", action
-            return valid, {action_str:action_str,action_params:action_params}, action
-       
-        except KeyError:
-            return False, llm_response, None
-
-    def parse_response(self, llm_response: str, state: Observation.state):
-        response_dict = {"action": None, "parameters": None}
-        valid = False
-        action = None
-
-        try:
-            response = json.loads(llm_response)
-            action_str = response.get("action", None)
-            action_params = response.get("parameters", None)
-            
-            if action_str and action_params:
-                valid, action = create_action_from_response(response, state)
-                response_dict["action"] = action_str
-                response_dict["parameters"] = action_params
-            else:
-                self.logger.warning("Missing action or parameters in LLM response.")
-        except json.JSONDecodeError:
-            self.logger.error("Failed to parse LLM response as JSON.")
-            response_dict["action"] = "InvalidJSON"
-            response_dict["parameters"] = llm_response  # Return raw response for debugging
-        except KeyError:
-            self.logger.error("Missing keys in LLM response.")
-        
-        return valid, response_dict, action
-
-    def remove_reasoning(self, text):
-        match = re.search(r'</think>(.*)', text, re.DOTALL)
-        if match:
-            return match.group(1).strip()
-        return text
-
-    def check_repetition(self, memory_list):
-        repetitions = 0
-        past_memories = []
-        for memory, goodness in memory_list:
-            if memory in past_memories:
-                repetitions += 1
-            past_memories.append(memory)
-        return repetitions
-
-    def get_self_consistent_response(self, messages, temp=0.4, max_tokens=1024, n=3, parent_span=None):
-        if parent_span and langfuse:
-            try:
-                with langfuse.start_as_current_span(name="self-consistency-check") as consistency_span:
-                    candidates = []
-                    for i in range(n):
-                        with langfuse.start_as_current_span(name=f"candidate-{i+1}") as candidate_span:
-                            response = self.openai_query(messages, temperature=temp, max_tokens=max_tokens, parent_span=candidate_span)
-                            candidates.append(response.strip())
-
-                    counts = Counter(candidates)
-                    most_common = counts.most_common(1)
-                    
-                    consistency_span.update(
-                        output={
-                            "candidates": candidates,
-                            "counts": dict(counts),
-                            "selected": most_common[0][0] if most_common else candidates[0]
-                        }
-                    )
-                    
-                    if most_common:
-                        self.logger.info(f"Self-consistency candidates: {counts}")
-                        return most_common[0][0]
-                    return candidates[0]
-            except Exception as e:
-                print(f"Warning: Error with self-consistency tracking: {e}")
-        
-        # Fallback without Langfuse
-        candidates = []
-        for i in range(n):
-            response = self.openai_query(messages, temperature=temp, max_tokens=max_tokens)
-            candidates.append(response.strip())
-
-        counts = Counter(candidates)
-        most_common = counts.most_common(1)
-        
-        if most_common:
-            self.logger.info(f"Self-consistency candidates: {counts}")
-            return most_common[0][0]
-        return candidates[0]
 
     def get_action_from_obs_react(self, observation: Observation, memory_buf: list) -> tuple:
-        # Create main span for this action planning only if Langfuse is available
-        if langfuse:
-            try:
-                # Use context manager directly
-                with langfuse.start_as_current_span(
-                    name="agent-action-planning",
-                    input={
-                        "observation_state": observation.state.as_json(),
-                        "memory_buffer": [{"action": mem, "goodness": good} for mem, good in memory_buf],
-                        "model_config": {
-                            "model": self.model,
-                            "use_reasoning": self.use_reasoning,
-                            "use_reflection": self.use_reflection,
-                            "use_self_consistency": self.use_self_consistency
-                        }
-                    },
-                    metadata={
-                        "agent_type": "REACT",
-                        "memory_length": len(memory_buf),
-                        "session_id": self.session_id
-                    }
-                ) as main_span:
-                    # Update trace attributes using langfuse client
-                    langfuse.update_current_trace(
-                        session_id=self.session_id,
-                        user_id="agent",
-                        tags=["REACT", "action-planning"]
-                    )
-                    print(f"✅ Created main span for action planning")
-                    return self._execute_planning_logic(observation, memory_buf, main_span)
-            except Exception as e:
-                print(f"Warning: Could not create Langfuse span: {e}")
-                # Fallback without Langfuse
-                return self._execute_planning_logic(observation, memory_buf, None)
-        else:
-            return self._execute_planning_logic(observation, memory_buf, None)
-
-    def _execute_planning_logic(self, observation: Observation, memory_buf: list, main_span=None) -> tuple:
-        try:
+        with self.tracer.start_span(
+            name="agent-action-planning",
+            input={
+                "observation_state": observation.state.as_json(),
+                "memory_buffer": [{"action": mem, "goodness": good} for mem, good in memory_buf],
+                "model_config": {
+                    "model": self.model,
+                    "use_reasoning": self.use_reasoning,
+                    "use_reflection": self.use_reflection,
+                    "use_self_consistency": self.use_self_consistency,
+                },
+            },
+            metadata={"agent_type": "REACT", "memory_length": len(memory_buf), "session_id": self.session_id},
+        ) as main_span:
             self.states.append(observation.state.as_json())
             status_prompt = create_status_from_state(observation.state)
-            q1 = self.config['questions'][0]['text']
-            q4 = self.config['questions'][3]['text']
-            cot_prompt = self.config['prompts']['COT_PROMPT']
+            q1 = self.config["questions"][0]["text"]
+            q4 = self.config["questions"][3]["text"]
+            cot_prompt = self.config["prompts"]["COT_PROMPT"]
             memory_prompt = self.create_mem_prompt(memory_buf)
-
             repetitions = self.check_repetition(memory_buf)
-            
-            # Stage 1: Reasoning/Planning
-            if langfuse and main_span:
-                with langfuse.start_as_current_span(
-                    name="stage1-reasoning",
-                    input={
-                        "repetitions": repetitions,
-                        "memory_length": len(memory_buf)
-                    }
-                ) as stage1_span:
-                    messages = [
-                        {"role": "user", "content": self.instructions},
-                        {"role": "user", "content": status_prompt},
-                        {"role": "user", "content": memory_prompt},
-                        {"role": "user", "content": q1},
-                    ]
-                    
-                    self.logger.info(f"Text sent to the LLM: {messages}")
 
-                    if self.use_self_consistency:
-                        response = self.get_self_consistent_response(messages, temp=repetitions/9, max_tokens=1024, parent_span=stage1_span)
-                    else:
-                        response = self.openai_query(messages, max_tokens=1024, parent_span=stage1_span)
-
-                    if self.use_reflection:
-                        with langfuse.start_as_current_span(name="reflection") as reflection_span:
-                            reflection_prompt = [
-                                {
-                                    "role": "user",
-                                    "content": f"""
-                                    Instructions: {self.instructions}
-                                    Task: {q1}
-
-                                    Status: {status_prompt}
-                                    Memory: {memory_prompt}
-
-                                    Reasoning:
-                                    {response}
-
-                                    Is this reasoning valid given the Instructions, Status, and Memory?
-                                    - If YES, repeat it exactly.
-                                    - If NO, output the corrected reasoning only (no commentary).
-                                    """
-                                }
-                            ]
-                            response = self.openai_query(reflection_prompt, max_tokens=1024, parent_span=reflection_span)
-
-                    # Optional: parse response if reasoning is expected and outputs <think> ... </think>
-                    if self.use_reasoning:
-                        response = self.remove_reasoning(response)
-                        
-                    stage1_span.update(output=response)
-                    self.logger.info(f"(Stage 1) Response from LLM: {response}")
-            else:
-                # Fallback without Langfuse
+            with self.tracer.start_span(
+                name="stage1-reasoning",
+                input={"repetitions": repetitions, "memory_length": len(memory_buf)},
+                parent_span=main_span,
+            ) as stage1_span:
                 messages = [
                     {"role": "user", "content": self.instructions},
                     {"role": "user", "content": status_prompt},
                     {"role": "user", "content": memory_prompt},
                     {"role": "user", "content": q1},
                 ]
-                
-                self.logger.info(f"Text sent to the LLM: {messages}")
-
                 if self.use_self_consistency:
-                    response = self.get_self_consistent_response(messages, temp=repetitions/9, max_tokens=1024)
+                    response = self.get_self_consistent_response(messages, temp=repetitions/9, max_tokens=1024, parent_span=stage1_span)
                 else:
-                    response = self.openai_query(messages, max_tokens=1024)
-
+                    response = self.llm_query(messages, max_tokens=1024, parent_span=stage1_span)
                 if self.use_reflection:
-                    reflection_prompt = [
-                        {
-                            "role": "user",
-                            "content": f"""
-                            Instructions: {self.instructions}
-                            Task: {q1}
+                    with self.tracer.start_span(name="reflection", parent_span=stage1_span) as reflection_span:
+                        reflection_prompt = [
+                            {
+                                "role": "user",
+                                "content": f"""
+                                Instructions: {self.instructions}
+                                Task: {q1}
 
-                            Status: {status_prompt}
-                            Memory: {memory_prompt}
+                                Status: {status_prompt}
+                                Memory: {memory_prompt}
 
-                            Reasoning:
-                            {response}
+                                Reasoning:
+                                {response}
 
-                            Is this reasoning valid given the Instructions, Status, and Memory?
-                            - If YES, repeat it exactly.
-                            - If NO, output the corrected reasoning only (no commentary).
-                            """
-                        }
-                    ]
-                    response = self.openai_query(reflection_prompt, max_tokens=1024)
-
+                                Is this reasoning valid given the Instructions, Status, and Memory?
+                                - If YES, repeat it exactly.
+                                - If NO, output the corrected reasoning only (no commentary).
+                                """,
+                            }
+                        ]
+                        response = self.llm_query(reflection_prompt, max_tokens=1024, parent_span=reflection_span)
                 if self.use_reasoning:
                     response = self.remove_reasoning(response)
-                    
-                self.logger.info(f"(Stage 1) Response from LLM: {response}")
+                try:
+                    stage1_span.update(output=response)
+                except Exception:
+                    pass
 
-            # Stage 2: Action Selection
-            if langfuse and main_span:
-                with langfuse.start_as_current_span(name="stage2-action-selection") as stage2_span:
-                    messages = [
-                        {"role": "user", "content": self.instructions},
-                        {"role": "user", "content": status_prompt},
-                        {"role": "user", "content": cot_prompt},
-                        {"role": "user", "content": response},
-                        {"role": "user", "content": memory_prompt},
-                        {"role": "user", "content": q4},
-                    ]
-                    
-                    stage2_span.update(input={"messages": messages})
-                    self.prompts.append(messages)
-                    
-                    action_response = self.openai_query(messages, max_tokens=80, fmt={"type": "json_object"}, parent_span=stage2_span)
-                    
-                    # Validation
-                    validated, error_msg = validate_responses.validate_agent_response(action_response)
-                    
-                    if validated is None:
-                        self.logger.info(f"Invalid response format: {action_response} - Error: {error_msg}")
-                        
-                        try:
-                            parsed_response = json.loads(action_response)
-                        except json.JSONDecodeError:
-                            parsed_response = action_response
-
-                        action_response = json.dumps({
-                            "action": "InvalidResponse",
-                            "parameters": {
-                                "error": error_msg,
-                                "original": parsed_response
-                            }
-                        }, indent=2)
-
-                    if self.use_reasoning:
-                        action_response = self.remove_reasoning(action_response)
-
-                    stage2_span.update(output=action_response)
-                    
-                    self.responses.append(action_response)
-                    self.logger.info(f"(Stage 2) Response from LLM: {action_response}")
-                    print(f"(Stage 2) Response from LLM: {action_response}")
-                    
-                    # Parse final response
-                    valid, response_dict, action = self.parse_response(action_response, observation.state)
-                    
-                    # Update main trace with final results using langfuse client
-                    langfuse.update_current_trace(
-                        output={
-                            "valid_response": valid,
-                            "selected_action": response_dict,
-                            "final_response": action_response
-                        }
-                    )
-                    
-                    return valid, response_dict, action
-            else:
-                # Fallback without Langfuse
+            with self.tracer.start_span(name="stage2-action-selection", parent_span=main_span) as stage2_span:
                 messages = [
                     {"role": "user", "content": self.instructions},
                     {"role": "user", "content": status_prompt},
@@ -506,77 +107,36 @@ class LLMActionPlanner:
                     {"role": "user", "content": memory_prompt},
                     {"role": "user", "content": q4},
                 ]
-                
+                try:
+                    stage2_span.update(input={"messages": messages})
+                except Exception:
+                    pass
                 self.prompts.append(messages)
-                
-                action_response = self.openai_query(messages, max_tokens=80, fmt={"type": "json_object"})
-                
-                # Validation
+                action_response = self.llm_query(messages, max_tokens=80, fmt={"type": "json_object"}, parent_span=stage2_span)
                 validated, error_msg = validate_responses.validate_agent_response(action_response)
-                
                 if validated is None:
-                    self.logger.info(f"Invalid response format: {action_response} - Error: {error_msg}")
-                    
                     try:
                         parsed_response = json.loads(action_response)
                     except json.JSONDecodeError:
                         parsed_response = action_response
-
-                    action_response = json.dumps({
-                        "action": "InvalidResponse",
-                        "parameters": {
-                            "error": error_msg,
-                            "original": parsed_response
-                        }
-                    }, indent=2)
-
+                    action_response = json.dumps({"action": "InvalidResponse", "parameters": {"error": error_msg, "original": parsed_response}}, indent=2)
                 if self.use_reasoning:
                     action_response = self.remove_reasoning(action_response)
-                
-                self.responses.append(action_response)
-                self.logger.info(f"(Stage 2) Response from LLM: {action_response}")
-                print(f"(Stage 2) Response from LLM: {action_response}")
-                
-                # Parse final response
-                valid, response_dict, action = self.parse_response(action_response, observation.state)
-                
-                return valid, response_dict, action
-                
-        except Exception as e:
-            self.logger.error(f"Error in _execute_planning_logic: {str(e)}")
-            if langfuse and main_span:
                 try:
-                    langfuse.update_current_trace(
-                        output={"error": str(e)},
-                        level="ERROR"
-                    )
-                except Exception as langfuse_error:
-                    print(f"Warning: Could not update trace with error: {langfuse_error}")
-            raise
-    
-    def score_action_outcome(self, action_success: bool, reward: float = None, comment: str = None):
-        """Score the outcome with correct Langfuse v3 API"""
-        if langfuse:
-            try:
-                score_value = 1.0 if action_success else 0.0
-                if reward is not None:
-                    score_value = reward
-                
-                # Get current trace ID
-                current_trace_id = langfuse.get_current_trace_id()
-                if current_trace_id:
-                    langfuse.score(
-                        trace_id=current_trace_id,
-                        name="action-outcome",
-                        value=score_value,
-                        comment=comment or ("Success" if action_success else "Failed")
-                    )
-                    print(f"✅ Scored action outcome: {score_value}")
-                else:
-                    print("Warning: No active trace to score")
-            except Exception as e:
-                print(f"Warning: Could not score action outcome: {e}")
-    
-    def __del__(self):
-        """Cleanup when object is destroyed."""
-        pass
+                    stage2_span.update(output=action_response)
+                except Exception:
+                    pass
+                self.responses.append(action_response)
+                valid, response_dict, action = self.parse_response(action_response, observation.state)
+                try:
+                    stage2_span.update(metadata={"parsed": response_dict})
+                except Exception:
+                    pass
+                return valid, response_dict, action
+
+    def score_action_outcome(self, action_success: bool, reward: float = None, comment: str = None) -> None:
+        with self.tracer.start_span(
+            name="action-outcome",
+            input={"success": action_success, "reward": reward, "comment": comment},
+        ):
+            pass

--- a/agents/attackers/llm_qa/llm_action_planner_base.py
+++ b/agents/attackers/llm_qa/llm_action_planner_base.py
@@ -1,0 +1,192 @@
+from __future__ import annotations
+import sys
+from os import path
+import yaml
+import logging
+import json
+import jinja2
+import re
+from collections import Counter
+from typing import Any, List
+from tenacity import retry, stop_after_attempt
+
+# Make sure project modules are importable
+sys.path.append(path.dirname(path.dirname(path.dirname(path.dirname(path.dirname(path.abspath(__file__)))))))
+sys.path.append(path.dirname(path.dirname(path.dirname(path.abspath(__file__)))))
+
+from AIDojoCoordinator.game_components import Observation
+from NetSecGameAgents.agents.llm_utils import create_action_from_response
+
+class ConfigLoader:
+    """Class to handle loading YAML configurations."""
+
+    @staticmethod
+    def load_config(file_name: str = "prompts.yaml") -> dict:
+        possible_paths = [
+            path.join(path.dirname(__file__), file_name),
+            path.join(path.dirname(path.dirname(__file__)), file_name),
+            path.join(path.dirname(path.dirname(path.dirname(__file__))), file_name),
+        ]
+        for yaml_file in possible_paths:
+            if path.exists(yaml_file):
+                with open(yaml_file, "r") as file:
+                    return yaml.safe_load(file)
+        raise FileNotFoundError(f"{file_name} not found in expected directories.")
+
+class LLMActionPlannerBase:
+    """Base class for LLM-based action planners."""
+
+    def __init__(
+        self,
+        model_name: str,
+        goal: str,
+        llm,
+        tracer,
+        memory_len: int = 10,
+        config: dict | None = None,
+        use_reasoning: bool = False,
+        use_reflection: bool = False,
+        use_self_consistency: bool = False,
+    ) -> None:
+        self.model = model_name
+        self.llm = llm
+        self.tracer = tracer
+        self.config = config or ConfigLoader.load_config()
+        self.use_reasoning = use_reasoning
+        self.use_reflection = use_reflection
+        self.use_self_consistency = use_self_consistency
+        self.memory_len = memory_len
+        self.logger = logging.getLogger("REACT-agent")
+        self.update_instructions(goal.lower())
+        self.prompts: List[str] = []
+        self.states: List[Any] = []
+        self.responses: List[Any] = []
+        self.session_id = f"agent-session-{hash(goal)}"
+
+    def get_prompts(self) -> List[str]:
+        return self.prompts
+
+    def get_responses(self) -> List[Any]:
+        return self.responses
+
+    def get_states(self) -> List[Any]:
+        return self.states
+
+    def update_instructions(self, new_goal: str) -> None:
+        template = jinja2.Environment().from_string(
+            self.config["prompts"]["INSTRUCTIONS_TEMPLATE"]
+        )
+        self.instructions = template.render(goal=new_goal)
+
+    def create_mem_prompt(self, memory_list: list) -> str:
+        prompt = ""
+        for memory, goodness in memory_list:
+            prompt += (
+                f"You have taken action {memory} in the past. This action was {goodness}.\n"
+            )
+        return prompt
+
+    @retry(stop=stop_after_attempt(3))
+    def llm_query(
+        self,
+        msg_list: list,
+        max_tokens: int = 60,
+        model: str | None = None,
+        fmt=None,
+        temperature: float = 0.0,
+        parent_span=None,
+    ) -> str:
+        with self.tracer.start_generation(
+            name="llm-query",
+            model=model or self.model,
+            input=msg_list,
+            model_parameters={
+                "max_tokens": max_tokens,
+                "temperature": temperature,
+                "response_format": str(fmt) if fmt else "text",
+            },
+            parent_span=parent_span,
+        ) as generation:
+            llm_response = self.llm.chat(
+                model=model or self.model,
+                messages=msg_list,
+                max_tokens=max_tokens,
+                temperature=temperature,
+                response_format=fmt or {"type": "text"},
+            )
+            response_content = llm_response.choices[0].message.content
+
+            if generation and hasattr(llm_response, "usage") and llm_response.usage:
+                usage_dict = {
+                    "input_tokens": llm_response.usage.prompt_tokens,
+                    "output_tokens": llm_response.usage.completion_tokens,
+                    "total_tokens": llm_response.usage.total_tokens,
+                }
+                try:
+                    generation.update(output=response_content, usage=usage_dict)
+                except Exception:
+                    pass
+            return response_content
+
+    def parse_response(self, llm_response: str, state: Observation.state):
+        response_dict = {"action": None, "parameters": None}
+        valid = False
+        action = None
+        try:
+            response = json.loads(llm_response)
+            action_str = response.get("action", None)
+            action_params = response.get("parameters", None)
+            if action_str and action_params:
+                valid, action = create_action_from_response(response, state)
+                response_dict["action"] = action_str
+                response_dict["parameters"] = action_params
+            else:
+                self.logger.warning("Missing action or parameters in LLM response.")
+        except json.JSONDecodeError:
+            self.logger.error("Failed to parse LLM response as JSON.")
+            response_dict["action"] = "InvalidJSON"
+            response_dict["parameters"] = llm_response
+        except KeyError:
+            self.logger.error("Missing keys in LLM response.")
+        return valid, response_dict, action
+
+    def remove_reasoning(self, text: str) -> str:
+        match = re.search(r"</think>(.*)", text, re.DOTALL)
+        if match:
+            return match.group(1).strip()
+        return text
+
+    def check_repetition(self, memory_list: list) -> int:
+        repetitions = 0
+        past_memories = []
+        for memory, goodness in memory_list:
+            if memory in past_memories:
+                repetitions += 1
+            past_memories.append(memory)
+        return repetitions
+
+    def get_self_consistent_response(
+        self,
+        messages,
+        temp: float = 0.4,
+        max_tokens: int = 1024,
+        n: int = 3,
+        parent_span=None,
+    ) -> str:
+        with self.tracer.start_span(name="self-consistency-check"):
+            candidates = []
+            for i in range(n):
+                with self.tracer.start_span(name=f"candidate-{i+1}"):
+                    response = self.llm_query(
+                        messages,
+                        temperature=temp,
+                        max_tokens=max_tokens,
+                        parent_span=parent_span,
+                    )
+                    candidates.append(response.strip())
+            counts = Counter(candidates)
+            most_common = counts.most_common(1)
+            if most_common:
+                self.logger.info(f"Self-consistency candidates: {counts}")
+                return most_common[0][0]
+            return candidates[0]

--- a/agents/attackers/llm_qa/llm_client.py
+++ b/agents/attackers/llm_qa/llm_client.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+from typing import Any, Dict
+from openai import OpenAI
+
+class LLMClient:
+    """Simple wrapper around OpenAI client for OpenAI-compatible endpoints."""
+    def __init__(self, api_key: str | None = None, base_url: str | None = None) -> None:
+        if base_url:
+            self._client = OpenAI(api_key=api_key, base_url=base_url)
+        else:
+            self._client = OpenAI(api_key=api_key)
+
+    def chat(self, **kwargs: Any):
+        return self._client.chat.completions.create(**kwargs)

--- a/agents/attackers/llm_qa/tracer.py
+++ b/agents/attackers/llm_qa/tracer.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+from contextlib import contextmanager
+from typing import Any, Optional
+
+class _NoopSpan:
+    def update(self, **kwargs: Any) -> None:
+        pass
+
+class ITracer:
+    """Interface for tracing LLM interactions."""
+    @contextmanager
+    def start_span(self, name: str, **kwargs: Any):  # type: ignore
+        yield _NoopSpan()
+
+    @contextmanager
+    def start_generation(self, name: str, **kwargs: Any):  # type: ignore
+        yield _NoopSpan()
+
+class NoopTracer(ITracer):
+    """Tracer that performs no operations."""
+    pass
+
+class LangfuseTracer(ITracer):
+    """Tracer backed by Langfuse if available."""
+    def __init__(self) -> None:
+        from langfuse import Langfuse
+        self.client = Langfuse()
+
+    @contextmanager
+    def start_span(self, name: str, **kwargs: Any):  # type: ignore
+        with self.client.start_as_current_span(name=name, **kwargs) as span:
+            yield span
+
+    @contextmanager
+    def start_generation(self, name: str, **kwargs: Any):  # type: ignore
+        with self.client.start_as_current_generation(name=name, **kwargs) as generation:
+            yield generation
+
+def get_tracer(enabled: bool = False) -> ITracer:
+    """Return a tracer instance. Uses Langfuse if enabled and available."""
+    if not enabled:
+        return NoopTracer()
+    try:
+        return LangfuseTracer()
+    except Exception:
+        return NoopTracer()


### PR DESCRIPTION
## Summary
- add tracer abstraction with optional Langfuse support
- create unified LLM client and base planner class
- refactor QA agent and planner to use injected client and tracer with configurable base URL

## Testing
- `python -m py_compile agents/attackers/llm_qa/tracer.py agents/attackers/llm_qa/llm_client.py agents/attackers/llm_qa/llm_action_planner_base.py agents/attackers/llm_qa/llm_action_planner.py agents/attackers/llm_qa/llm_agent_qa.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68af0bf15f8483228407101cdaf76333